### PR TITLE
Save files on execution with a config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ It is also important that attaching a debugger will create a new debugger instan
 ## Contributors
 * [mrexodia](https://github.com/mrexodia)
 * [MeitarR](https://github.com/MeitarR)
+* [Plutoberth](https://github.com/Plutoberth)

--- a/ida/idacode_utils/plugin.py
+++ b/ida/idacode_utils/plugin.py
@@ -10,7 +10,7 @@ import idacode_utils.hooks as hooks
 import idacode_utils.settings as settings
 from idacode_utils.socket_handler import SocketHandler
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 initialized = False
 
 def setup_patches():

--- a/idacode/CHANGELOG.md
+++ b/idacode/CHANGELOG.md
@@ -18,3 +18,7 @@
 ### 0.1.3
 
 - Added support for Python 2
+
+### 0.1.4
+
+- Added "Save on execute" support in settings

--- a/idacode/README.md
+++ b/idacode/README.md
@@ -55,3 +55,7 @@ IDACode doesn't support host to VM communication unless the VM uses a shared vol
 ### 0.1.3
 
 - Added support for Python 2
+
+### 0.1.4
+
+- Added "Save on execute" support in settings

--- a/idacode/package-lock.json
+++ b/idacode/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "idacode",
-	"version": "0.0.1",
+	"version": "0.1.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/idacode/package.json
+++ b/idacode/package.json
@@ -3,7 +3,7 @@
     "displayName": "IDACode",
     "description": "Run and debug your IDA scripts from VS Code",
     "icon": "images/icon.png",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "publisher": "Layle",
     "license": "SEE LICENSE IN LICENSE.md",
     "preview": true,

--- a/idacode/package.json
+++ b/idacode/package.json
@@ -71,6 +71,11 @@
                     "type": "integer",
                     "default": 7066,
                     "description": "The port the IDA debug server is listening on."
+                },
+                "IDACode.saveOnExecute": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Save all open editors when executing."
                 }
             }
         }

--- a/idacode/src/extension.ts
+++ b/idacode/src/extension.ts
@@ -16,6 +16,11 @@ function getCurrentDocument(): string {
 }
 
 function executeScript() {
+    if (getConfig<boolean>('saveOnExecute'))
+    {
+        vscode.workspace.saveAll().then();   
+    }
+
     const currentDocument = getCurrentDocument();
     const name = path.parse(currentDocument).base;
     socket.send({

--- a/idacode/src/extension.ts
+++ b/idacode/src/extension.ts
@@ -15,12 +15,7 @@ function getCurrentDocument(): string {
     return vscode.window.activeTextEditor?.document.uri.fsPath as string;
 }
 
-function executeScript() {
-    if (getConfig<boolean>('saveOnExecute'))
-    {
-        vscode.workspace.saveAll().then();   
-    }
-
+function executeScriptInIDA() {
     const currentDocument = getCurrentDocument();
     const name = path.parse(currentDocument).base;
     socket.send({
@@ -28,6 +23,14 @@ function executeScript() {
         path: currentDocument
     }.toBuffer());
     vscode.window.showInformationMessage(`Sent ${name} to IDA`);
+}
+
+function executeScript() {
+    if (getConfig<boolean>('saveOnExecute')) {
+        vscode.workspace.saveAll().then(executeScriptInIDA);
+    } else {
+        executeScriptInIDA();
+    }
 }
 
 function connectToIDA() {


### PR DESCRIPTION
When running or debugging scripts in vscode, all open dirty editors are automatically saved. I added this functionality as a config option ("IDACode.saveOnExecute") that is enabled by default.