### PR TITLE
Fix for tornado/asyncio.set_event_loop on Windows and Python 3.8

### DIFF
--- a/ida/idacode_utils/plugin.py
+++ b/ida/idacode_utils/plugin.py
@@ -33,7 +33,7 @@ def create_socket_handler():
 
 def start_server():
     # Fix for https://github.com/tornadoweb/tornado/issues/2608
-	if sys.platform=='win32':
+	if sys.platform=='win32' and sys.version_info >= (3,8):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     
     setup_patches()

--- a/ida/idacode_utils/plugin.py
+++ b/ida/idacode_utils/plugin.py
@@ -10,6 +10,9 @@ import idacode_utils.hooks as hooks
 import idacode_utils.settings as settings
 from idacode_utils.socket_handler import SocketHandler
 
+# Fix for https://github.com/tornadoweb/tornado/issues/2608
+import asyncio
+
 VERSION = "0.1.4"
 initialized = False
 
@@ -29,6 +32,10 @@ def create_socket_handler():
     server.listen(address=settings.HOST, port=settings.PORT)
 
 def start_server():
+    # Fix for https://github.com/tornadoweb/tornado/issues/2608
+	if sys.platform=='win32':
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    
     setup_patches()
     create_socket_handler()
     tornado.ioloop.IOLoop.current().start()

--- a/ida/idacode_utils/plugin.py
+++ b/ida/idacode_utils/plugin.py
@@ -33,7 +33,7 @@ def create_socket_handler():
 
 def start_server():
     # Fix for https://github.com/tornadoweb/tornado/issues/2608
-	if sys.platform=='win32' and sys.version_info >= (3,8):
+    if sys.platform=='win32' and sys.version_info >= (3,8):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     
     setup_patches()


### PR DESCRIPTION
Fix for tornado/asyncio.set_event_loop on Windows and Python 3.8

Mitigated by setting a default policy during socket setup.